### PR TITLE
Improving small object GETs latency 

### DIFF
--- a/client/client_apis.go
+++ b/client/client_apis.go
@@ -188,11 +188,23 @@ func (client *ACSClient) GetObject(ctx context.Context, bucket, key string, opti
 			return nil, fmt.Errorf("failed to start GetObject stream: %v", err)
 		}
 
-		// Initialize a large buffer - 32MB initial size for better streaming performance
-		buf := bytes.NewBuffer(make([]byte, 0, 32*1024*1024))
-		firstMessage := true
-		isCompressed := false
+		// Get first message to check metadata
+		resp, err := stream.Recv()
+		if err != nil {
+			return nil, fmt.Errorf("error receiving metadata: %v", err)
+		}
 
+		metadata := resp.GetMetadata()
+		if metadata == nil {
+			return nil, fmt.Errorf("missing metadata in first message")
+		}
+
+		isCompressed := metadata.GetIsCompressed()
+
+		// Start with a smaller initial buffer (64KB) and grow as needed
+		buf := bytes.NewBuffer(make([]byte, 0, 64*1024))
+
+		// Read all chunks
 		for {
 			resp, err := stream.Recv()
 			if err == io.EOF {
@@ -201,17 +213,6 @@ func (client *ACSClient) GetObject(ctx context.Context, bucket, key string, opti
 			if err != nil {
 				return nil, fmt.Errorf("error receiving chunk: %v", err)
 			}
-
-			// Process metadata message
-			if firstMessage {
-				firstMessage = false
-				if metadata := resp.GetMetadata(); metadata != nil {
-					isCompressed = metadata.GetIsCompressed()
-				}
-				continue
-			}
-
-			// Write chunk directly to buffer
 			if chunk := resp.GetChunk(); chunk != nil {
 				if _, err := buf.Write(chunk); err != nil {
 					return nil, fmt.Errorf("error writing chunk: %v", err)
@@ -219,7 +220,6 @@ func (client *ACSClient) GetObject(ctx context.Context, bucket, key string, opti
 			}
 		}
 
-		// Get the final data
 		data := buf.Bytes()
 
 		// Decompress data if it was compressed

--- a/client/client_apis.go
+++ b/client/client_apis.go
@@ -201,8 +201,8 @@ func (client *ACSClient) GetObject(ctx context.Context, bucket, key string, opti
 
 		isCompressed := metadata.GetIsCompressed()
 
-		// Start with a smaller initial buffer (64KB) and grow as needed
-		buf := bytes.NewBuffer(make([]byte, 0, 64*1024))
+		// Start with a small initial buffer (256KB) and grow as needed
+		buf := bytes.NewBuffer(make([]byte, 0, 256*1024))
 
 		// Read all chunks
 		for {


### PR DESCRIPTION
This pull request refactors the `GetObject` method in `client/client_apis.go` to improve performance and simplify the handling of metadata and streaming. The most important changes include moving metadata processing to the beginning of the stream, reducing the initial buffer size, and removing redundant logic for handling the first message.

### Refactoring of metadata handling and buffer initialization:

* Metadata is now processed immediately after receiving the first message, ensuring that the `isCompressed` flag is set early and simplifying the loop logic. [[1]](diffhunk://#diff-cfe438157bde645a17fe6e276b60ffc925b38ed82c0dd3fb5e55e49530906b99L191-R207) [[2]](diffhunk://#diff-cfe438157bde645a17fe6e276b60ffc925b38ed82c0dd3fb5e55e49530906b99L204-L222)
* The initial buffer size has been reduced from 32MB to 64KB, optimizing memory usage while still allowing for dynamic growth as needed.

### Simplification of streaming logic:

* Removed the `firstMessage` flag and associated conditional logic, as metadata is now handled before entering the main loop. This change makes the code more straightforward and easier to maintain.